### PR TITLE
Add working authentication

### DIFF
--- a/one_thing/mock-db.sql
+++ b/one_thing/mock-db.sql
@@ -1,13 +1,12 @@
 -- SQLite
 INSERT INTO `things` (personId, description)
 VALUES
-  (2, "Prepare for the upcoming diversity GA panel"),
-  (3, "Write up a plan for this quarter's 1on1s")
+  (1, "Prepare for the upcoming diversity GA panel"),
+  (2, "Write up a plan for this quarter's 1on1s")
 ;
 
-INSERT INTO `persons` (firstName, lastName, email)
+INSERT INTO `persons` (firstName, lastName, email, auth0UserId)
 VALUES
-  ("Zach", "Hammer", "zhammer@seatgeek.com"),
-  ("Laura", "Lennon", "llennon@seatgeek.com"),
-  ("Chris", "Gray", "zhammer@seatgeek.com")
+  ("Laura", "Lennon", "llennon@seatgeek.com", "auth0id1"),
+  ("Chris", "Gray", "zhammer@seatgeek.com", "auth0id2")
 ;

--- a/one_thing/package.json
+++ b/one_thing/package.json
@@ -9,6 +9,8 @@
     "clean-webpack-plugin": "^2.0.1",
     "graphql-tag": "^2.10.1",
     "jest": "^24.7.1",
+    "prettier": "^1.16.4",
+    "sqlite3": "^4.0.6",
     "ts-jest": "^24.0.2",
     "ts-loader": "^5.3.3",
     "typescript": "^3.4.2",
@@ -17,10 +19,20 @@
     "webpack-merge": "^4.2.1",
     "webpack-node-externals": "^1.7.2"
   },
+  "prettier": {
+    "tabWidth": 2,
+    "singleQuote": true,
+    "printWidth": 100
+  },
   "dependencies": {
+    "@types/jsonwebtoken": "^8.3.2",
+    "@types/superagent": "^4.1.1",
     "apollo-server": "^2.4.8",
     "date-fns": "^1.30.1",
     "graphql": "^14.2.1",
+    "jsonwebtoken": "^8.5.1",
+    "jwks-rsa": "^1.4.0",
+    "superagent": "^5.0.2",
     "typeorm": "^0.2.16"
   }
 }

--- a/one_thing/src/delivery/apollo/auth.ts
+++ b/one_thing/src/delivery/apollo/auth.ts
@@ -1,8 +1,8 @@
-import jwt from "jsonwebtoken";
-import jwksClient from "jwks-rsa";
+import jwt from 'jsonwebtoken';
+import jwksClient from 'jwks-rsa';
 
 const client = jwksClient({
-  jwksUri: "https://zhammer.auth0.com/.well-known/jwks.json"
+  jwksUri: 'https://zhammer.auth0.com/.well-known/jwks.json'
 });
 
 function getKey(header: any, cb: any) {
@@ -13,14 +13,12 @@ function getKey(header: any, cb: any) {
 }
 
 const jwtOptions = {
-  audience: "https://zhammer.auth0.com/api/v2/",
-  issuer: "https://zhammer.auth0.com/",
-  algorithms: ["RS256"]
+  audience: 'https://zhammer.auth0.com/api/v2/',
+  issuer: 'https://zhammer.auth0.com/',
+  algorithms: ['RS256']
 };
 
-export async function parseJWT(
-  authorization: string
-): Promise<{ sub: string }> {
+export async function parseJWT(authorization: string): Promise<{ sub: string }> {
   return await new Promise((resolve, reject) => {
     jwt.verify(authorization!, getKey, jwtOptions, (err, decoded) => {
       if (err) {

--- a/one_thing/src/delivery/apollo/auth.ts
+++ b/one_thing/src/delivery/apollo/auth.ts
@@ -18,9 +18,14 @@ const jwtOptions = {
   algorithms: ['RS256']
 };
 
-export async function parseJWT(authorization: string): Promise<{ sub: string }> {
+/**
+ * Parses a one-thing auth0 accesstoken and returns an object with the 'sub' id
+ * of the user in auth0.
+ * @param accessToken Authorization header value.
+ */
+export async function parseJWT(accessToken: string): Promise<{ sub: string }> {
   return await new Promise((resolve, reject) => {
-    jwt.verify(authorization!, getKey, jwtOptions, (err, decoded) => {
+    jwt.verify(accessToken!, getKey, jwtOptions, (err, decoded) => {
       if (err) {
         return reject(err);
       }

--- a/one_thing/src/delivery/apollo/auth.ts
+++ b/one_thing/src/delivery/apollo/auth.ts
@@ -1,0 +1,32 @@
+import jwt from "jsonwebtoken";
+import jwksClient from "jwks-rsa";
+
+const client = jwksClient({
+  jwksUri: "https://zhammer.auth0.com/.well-known/jwks.json"
+});
+
+function getKey(header: any, cb: any) {
+  client.getSigningKey(header.kid, (err, key) => {
+    const signingKey = key.publicKey || key.rsaPublicKey;
+    cb(null, signingKey);
+  });
+}
+
+const jwtOptions = {
+  audience: "https://zhammer.auth0.com/api/v2/",
+  issuer: "https://zhammer.auth0.com/",
+  algorithms: ["RS256"]
+};
+
+export async function parseJWT(
+  authorization: string
+): Promise<{ sub: string }> {
+  return await new Promise((resolve, reject) => {
+    jwt.verify(authorization!, getKey, jwtOptions, (err, decoded) => {
+      if (err) {
+        return reject(err);
+      }
+      resolve(decoded as { sub: string });
+    });
+  });
+}

--- a/one_thing/src/delivery/apollo/index.ts
+++ b/one_thing/src/delivery/apollo/index.ts
@@ -46,11 +46,17 @@ async function getAuth0UserId(request: Request): Promise<string> {
     throw new AuthenticationError('Missing bearer token.');
   }
 
+  const match = request.headers.authorization.match(/Bearer (.*)/);
+  const accessToken = match && match[1];
+  if (!accessToken) {
+    throw new AuthenticationError('Invalid Bearer token');
+  }
+
   let jwtBody: { sub: string } | null;
   try {
-    jwtBody = await parseJWT(request.headers.authorization);
+    jwtBody = await parseJWT(accessToken);
   } catch (err) {
-    throw new AuthenticationError('Invalid Bearer token.');
+    throw new AuthenticationError('Couldnt parse access token.');
   }
   return jwtBody.sub;
 }

--- a/one_thing/src/delivery/apollo/resolvers.ts
+++ b/one_thing/src/delivery/apollo/resolvers.ts
@@ -1,12 +1,12 @@
-import { RelayConnection, Context } from "./types";
-import { Thing, Person } from "../../types";
+import { RelayConnection, Context } from './types';
+import { Thing, Person } from '../../types';
 import {
   getAllThingsThisWeek,
   submitThing,
   completePersonsThingThisWeek,
   getPersonsThingThisWeek
-} from "../../useThings";
-import { getPerson } from "../../usePersons";
+} from '../../useThings';
+import { getPerson } from '../../usePersons';
 
 export default {
   Query: {
@@ -28,13 +28,7 @@ export default {
       };
     },
     async me(_: any, __: any, context: Context): Promise<Person> {
-      const person = await getPerson(context.gateways, context.authInfo.userId);
-      if (!person) {
-        throw new Error(
-          `Couldnt find person with id ${context.authInfo.userId}`
-        );
-      }
-      return person;
+      return context.authInfo.person;
     }
   },
   Mutation: {
@@ -43,35 +37,20 @@ export default {
       args: { description: string },
       context: Context
     ): Promise<{ success: boolean }> {
-      await submitThing(
-        context.gateways,
-        context.authInfo.userId,
-        args.description
-      );
+      await submitThing(context.gateways, context.authInfo.person.id, args.description);
       return {
         success: true
       };
     },
-    async completeThingThisWeek(
-      _: any,
-      __: any,
-      context: Context
-    ): Promise<{ success: boolean }> {
-      await completePersonsThingThisWeek(
-        context.gateways,
-        context.authInfo.userId
-      );
+    async completeThingThisWeek(_: any, __: any, context: Context): Promise<{ success: boolean }> {
+      await completePersonsThingThisWeek(context.gateways, context.authInfo.person.id);
       return {
         success: true
       };
     }
   },
   Person: {
-    async thingThisWeek(
-      person: Person,
-      _: any,
-      { gateways }: Context
-    ): Promise<Thing | null> {
+    async thingThisWeek(person: Person, _: any, { gateways }: Context): Promise<Thing | null> {
       return await getPersonsThingThisWeek(gateways, person.id);
     }
   },

--- a/one_thing/src/delivery/apollo/types.ts
+++ b/one_thing/src/delivery/apollo/types.ts
@@ -1,9 +1,9 @@
-import { Gateways } from "../../types";
+import { Gateways, Person } from '../../types';
 
 export interface Context {
   gateways: Gateways;
   authInfo: {
-    userId: string;
+    person: Person;
   };
 }
 

--- a/one_thing/src/delivery/dev.ts
+++ b/one_thing/src/delivery/dev.ts
@@ -1,4 +1,4 @@
-import { makeApolloServer } from "./apollo";
+import { makeApolloServer } from './apollo';
 
 const server = makeApolloServer({
   dev: true

--- a/one_thing/src/exceptions.ts
+++ b/one_thing/src/exceptions.ts
@@ -18,3 +18,10 @@ export class PersonDoesntExistError extends Error {
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }
+
+export class Auth0Error extends Error {
+  constructor(message?: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/one_thing/src/gateways/auth0Gateway.ts
+++ b/one_thing/src/gateways/auth0Gateway.ts
@@ -1,0 +1,30 @@
+import { Auth0Gateway as Auth0GatewayInterface, UserInfo } from "../types";
+import request from "superagent";
+import { Auth0Error } from "../exceptions";
+
+export default class Auth0Gateway implements Auth0GatewayInterface {
+  private url: string = "https://zhammer.auth0.com/api/v2";
+  private accessToken: string;
+
+  constructor(accessToken: string) {
+    this.accessToken = accessToken;
+  }
+
+  async fetchUserInfo(auth0UserId: string): Promise<UserInfo> {
+    const response = await request
+      .get(`${this.url}/users/${auth0UserId}`)
+      .set("Authorization", `Bearer ${this.accessToken}`);
+    if (response.status !== 200) {
+      throw new Auth0Error();
+    }
+    return pluckUserInfo(response.body);
+  }
+}
+
+function pluckUserInfo(body: any): UserInfo {
+  return {
+    email: body.email,
+    firstName: body.given_name,
+    lastName: body.family_name
+  };
+}

--- a/one_thing/src/gateways/auth0Gateway.ts
+++ b/one_thing/src/gateways/auth0Gateway.ts
@@ -1,9 +1,9 @@
-import { Auth0Gateway as Auth0GatewayInterface, UserInfo } from "../types";
-import request from "superagent";
-import { Auth0Error } from "../exceptions";
+import { Auth0Gateway as Auth0GatewayInterface, UserInfo } from '../types';
+import request from 'superagent';
+import { Auth0Error } from '../exceptions';
 
 export default class Auth0Gateway implements Auth0GatewayInterface {
-  private url: string = "https://zhammer.auth0.com/api/v2";
+  private url: string = 'https://zhammer.auth0.com/api/v2';
   private accessToken: string;
 
   constructor(accessToken: string) {
@@ -13,7 +13,7 @@ export default class Auth0Gateway implements Auth0GatewayInterface {
   async fetchUserInfo(auth0UserId: string): Promise<UserInfo> {
     const response = await request
       .get(`${this.url}/users/${auth0UserId}`)
-      .set("Authorization", `Bearer ${this.accessToken}`);
+      .set('Authorization', `Bearer ${this.accessToken}`);
     if (response.status !== 200) {
       throw new Auth0Error();
     }

--- a/one_thing/src/types.ts
+++ b/one_thing/src/types.ts
@@ -1,5 +1,6 @@
 export interface Gateways {
   databaseGateway: DatabaseGateway;
+  auth0Gateway: Auth0Gateway;
 }
 
 export interface ThingInput {
@@ -29,11 +30,25 @@ export type QueryOptions = {
 
 export interface DatabaseGateway {
   fetchThings: (options?: QueryOptions) => Promise<Thing[]>;
-  fetchThingsOfPerson: (
-    personId: string,
-    options?: QueryOptions
-  ) => Promise<Thing[]>;
+  fetchThingsOfPerson: (personId: string, options?: QueryOptions) => Promise<Thing[]>;
   addThing: (personId: string, description: string) => Promise<Thing>;
+  addPerson: (
+    auth0UserId: string,
+    email: string,
+    firstName: string,
+    lastName: string
+  ) => Promise<Person>;
   setThingComplete: (thingId: string) => Promise<null>;
   fetchPerson: (personId: string) => Promise<Person | null>;
+  fetchPersonByAuth0UserId: (auth0UserId: string) => Promise<Person | null>;
+}
+
+export interface UserInfo {
+  email: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface Auth0Gateway {
+  fetchUserInfo: (auth0UserId: string) => Promise<UserInfo>;
 }

--- a/one_thing/src/useAuth.ts
+++ b/one_thing/src/useAuth.ts
@@ -1,0 +1,10 @@
+import { Person, Gateways } from './types';
+
+export async function login(gateways: Gateways, auth0UserId: string): Promise<Person> {
+  const person = await gateways.databaseGateway.fetchPersonByAuth0UserId(auth0UserId);
+  if (person) {
+    return person;
+  }
+  const { email, firstName, lastName } = await gateways.auth0Gateway.fetchUserInfo(auth0UserId);
+  return await gateways.databaseGateway.addPerson(auth0UserId, email, firstName, lastName);
+}

--- a/one_thing/src/usePersons.ts
+++ b/one_thing/src/usePersons.ts
@@ -1,8 +1,5 @@
-import { Gateways, Person } from "./types";
+import { Gateways, Person } from './types';
 
-export async function getPerson(
-  gateways: Gateways,
-  personId: string
-): Promise<Person | null> {
+export async function getPerson(gateways: Gateways, personId: string): Promise<Person | null> {
   return await gateways.databaseGateway.fetchPerson(personId);
 }

--- a/one_thing/src/useThings.ts
+++ b/one_thing/src/useThings.ts
@@ -1,13 +1,8 @@
-import { Gateways, Thing } from "./types";
-import { weekTimeRange } from "./util";
-import {
-  AlreadySubmittedThingThisWeekError,
-  NoThingThisWeekError
-} from "./exceptions";
+import { Gateways, Thing } from './types';
+import { weekTimeRange } from './util';
+import { AlreadySubmittedThingThisWeekError, NoThingThisWeekError } from './exceptions';
 
-export async function getAllThingsThisWeek(
-  gateways: Gateways
-): Promise<Thing[]> {
+export async function getAllThingsThisWeek(gateways: Gateways): Promise<Thing[]> {
   const now = new Date();
   const { from, to } = weekTimeRange(now);
   return await gateways.databaseGateway.fetchThings({
@@ -45,14 +40,9 @@ export async function completePersonsThingThisWeek(
   gateways: Gateways,
   personId: string
 ): Promise<null> {
-  const personsThingThisWeek = await getPersonsThingThisWeek(
-    gateways,
-    personId
-  );
+  const personsThingThisWeek = await getPersonsThingThisWeek(gateways, personId);
   if (!personsThingThisWeek) {
     throw new NoThingThisWeekError();
   }
-  return await gateways.databaseGateway.setThingComplete(
-    personsThingThisWeek.id
-  );
+  return await gateways.databaseGateway.setThingComplete(personsThingThisWeek.id);
 }

--- a/one_thing/src/util.test.ts
+++ b/one_thing/src/util.test.ts
@@ -1,12 +1,12 @@
-import { weekTimeRange } from "./util";
+import { weekTimeRange } from './util';
 
-describe("weekTimeRange", () => {
-  it("returns the start and end dates of the week", () => {
-    const now = new Date("Sat Apr 06 2019 13:26:31 GMT");
+describe('weekTimeRange', () => {
+  it('returns the start and end dates of the week', () => {
+    const now = new Date('Sat Apr 06 2019 13:26:31 GMT');
     const range = weekTimeRange(now);
     const expected = {
-      from: new Date("Sun Mar 31 2019 00:00:00 GMT"),
-      to: new Date("Sun Apr 07 2019 00:00:00 GMT")
+      from: new Date('Sun Mar 31 2019 00:00:00 GMT'),
+      to: new Date('Sun Apr 07 2019 00:00:00 GMT')
     };
     expect(range).toEqual(expected);
   });

--- a/one_thing/src/util.ts
+++ b/one_thing/src/util.ts
@@ -1,4 +1,4 @@
-import { startOfWeek, addWeeks } from "date-fns";
+import { startOfWeek, addWeeks } from 'date-fns';
 
 export function weekTimeRange(now: Date): { from: Date; to: Date } {
   const lastSunday = startOfWeek(now);

--- a/one_thing/yarn.lock
+++ b/one_thing/yarn.lock
@@ -403,6 +403,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookiejar@*":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.1.tgz#90b68446364baf9efd8e8349bb36bd3852b75b80"
+  integrity sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==
+
 "@types/cors@^2.8.4":
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.4.tgz#50991a759a29c0b89492751008c6af7a7c8267b0"
@@ -415,6 +420,14 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
+"@types/express-jwt@0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@types/express-jwt/-/express-jwt-0.0.34.tgz#fdbee4c6af5c0a246ef2a933f5519973c7717f02"
+  integrity sha1-/b7kxq9cCiRu8qkz9VGZc8dxfwI=
+  dependencies:
+    "@types/express" "*"
+    "@types/express-unless" "*"
+
 "@types/express-serve-static-core@*":
   version "4.16.2"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.16.2.tgz#5ee8a22e602005be6767df6b2cba9879df3f75aa"
@@ -422,6 +435,13 @@
   dependencies:
     "@types/node" "*"
     "@types/range-parser" "*"
+
+"@types/express-unless@*":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@types/express-unless/-/express-unless-0.5.1.tgz#4f440b905e42bbf53382b8207bc337dc5ff9fd1f"
+  integrity sha512-5fuvg7C69lemNgl0+v+CUxDYWVPSfXHhJPst4yTLcqi4zKJpORCxnDrnnilk3k0DTq/WrAUdvXFs01+vUqUZHw==
+  dependencies:
+    "@types/express" "*"
 
 "@types/express@*", "@types/express@4.16.1":
   version "4.16.1"
@@ -448,6 +468,13 @@
   integrity sha512-2kLuPC5FDnWIDvaJBzsGTBQaBbnDweznicvK7UGYzlIJP4RJR2a4A/ByLUXEyEgag6jz8eHdlWExGDtH3EYUXQ==
   dependencies:
     "@types/jest-diff" "*"
+
+"@types/jsonwebtoken@^8.3.2":
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.3.2.tgz#e3d5245197152346fae7ee87d5541aa5a92d0362"
+  integrity sha512-Mkjljd9DTpkPlrmGfTJvcP4aBU7yO2QmW7wNVhV4/6AEUxYoacqU7FJU/N0yFEHTsIrE4da3rUrjrR5ejicFmA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/long@^4.0.0":
   version "4.0.0"
@@ -486,6 +513,14 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/superagent@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.1.tgz#61f0b43d7db93a3c286c124512b7c228183c32fa"
+  integrity sha512-NetXrraTWPcdGG6IwYJhJ5esUGx8AYNiozbc1ENWEsF6BsD4JmNODJczI6Rm1xFPVp6HZESds9YCfqz4zIsM6A==
+  dependencies:
+    "@types/cookiejar" "*"
+    "@types/node" "*"
 
 "@types/webpack-env@^1.13.9":
   version "1.13.9"
@@ -1314,6 +1349,11 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+
 buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -1641,6 +1681,11 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
+
+cookiejar@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
+  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -1973,6 +2018,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -2400,7 +2452,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@~2.3.2:
+form-data@^2.3.3, form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
   integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
@@ -2408,6 +2460,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formidable@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
+  integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -3648,6 +3705,22 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -3657,6 +3730,35 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jwks-rsa@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jwks-rsa/-/jwks-rsa-1.4.0.tgz#269cd2466afe7ab377fec55516f5e3019f22f0e5"
+  integrity sha512-6aUc+oTuqsLwIarfq3A0FqoD5LFSgveW5JO1uX2s0J8TJuOEcDc4NIMZAmVHO8tMHDw7CwOPzXF/9QhfOpOElA==
+  dependencies:
+    "@types/express-jwt" "0.0.34"
+    debug "^2.2.0"
+    limiter "^1.1.0"
+    lru-memoizer "^1.6.0"
+    ms "^2.0.0"
+    request "^2.73.0"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -3719,6 +3821,11 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+limiter@^1.1.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.4.tgz#87c9c3972d389fdb0ba67a45aadbc5d2f8413bc1"
+  integrity sha512-XCpr5bElgDI65vVgstP8TWjv6/QKWm9GU5UG0Pr5sLQ3QLo8NVKsioe+Jed5/3vFOe3IQuqE7DKwTvKQkjTHvg==
+
 load-json-file@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
@@ -3759,12 +3866,52 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lock@~0.1.2:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/lock/-/lock-0.1.4.tgz#fec7deaef17e7c3a0a55e1da042803e25d91745d"
+  integrity sha1-/sfervF+fDoKVeHaBCgD4l2RdF0=
+
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.11, lodash@^4.17.5:
+lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -3795,6 +3942,24 @@ lru-cache@^5.0.0, lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@~4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
+  integrity sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=
+  dependencies:
+    pseudomap "^1.0.1"
+    yallist "^2.0.0"
+
+lru-memoizer@^1.6.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/lru-memoizer/-/lru-memoizer-1.12.0.tgz#efe65706cc8a9cc653f80f0d5a6ea38ad950e352"
+  integrity sha1-7+ZXBsyKnMZT+A8NWm6jitlQ41I=
+  dependencies:
+    lock "~0.1.2"
+    lodash "^4.17.4"
+    lru-cache "~4.0.0"
+    very-fast-args "^1.1.0"
 
 make-dir@^1.3.0:
   version "1.3.0"
@@ -3897,7 +4062,7 @@ merge-stream@^1.0.1:
   dependencies:
     readable-stream "^2.0.1"
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -3945,6 +4110,11 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
+
+mime@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.1.tgz#19eb7357bebbda37df585b14038347721558c715"
+  integrity sha512-VRUfmQO0rCd3hKwBymAn3kxYzBHr3I/wdVMywgG3HhXOwrCQgN84ZagpdTm2tZ4TNtwsSmyJWYO88mb5XvzGqQ==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -4051,7 +4221,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.1.1:
+ms@^2.0.0, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
@@ -4069,6 +4239,11 @@ nan@^2.9.2:
   version "2.13.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
   integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
+
+nan@~2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+  integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -4175,6 +4350,22 @@ node-pre-gyp@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
   integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
+
+node-pre-gyp@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz#db1f33215272f692cd38f03238e3e9b47c5dd054"
+  integrity sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -4631,6 +4822,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^1.16.4:
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
+  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+
 pretty-format@^24.7.0:
   version "24.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.7.0.tgz#d23106bc2edcd776079c2daa5da02bcb12ed0c10"
@@ -4696,7 +4892,7 @@ prr@~1.0.1:
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
-pseudomap@^1.0.2:
+pseudomap@^1.0.1, pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
@@ -4762,6 +4958,11 @@ qs@6.5.2, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+qs@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -4848,6 +5049,15 @@ read-pkg@^3.0.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.3.0.tgz#cb8011aad002eb717bf040291feba8569c986fb9"
+  integrity sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readdirp@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
@@ -4908,7 +5118,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.87.0:
+request@^2.73.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -5073,6 +5283,11 @@ schema-utils@^1.0.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+
+semver@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.0.0.tgz#05e359ee571e5ad7ed641a6eec1e547ba52dea65"
+  integrity sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==
 
 send@0.16.2:
   version "0.16.2"
@@ -5295,6 +5510,15 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+sqlite3@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.0.6.tgz#e587b583b5acc6cb38d4437dedb2572359c080ad"
+  integrity sha512-EqBXxHdKiwvNMRCgml86VTL5TK1i0IKiumnfxykX0gh6H6jaKijAXvE9O1N7+omfNSawR2fOmIyJZcfe8HYWpw==
+  dependencies:
+    nan "~2.10.0"
+    node-pre-gyp "^0.11.0"
+    request "^2.87.0"
+
 sshpk@^1.7.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
@@ -5416,7 +5640,7 @@ string-width@^3.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string_decoder@^1.0.0:
+string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
   integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
@@ -5476,6 +5700,22 @@ subscriptions-transport-ws@^0.9.11:
     iterall "^1.2.1"
     symbol-observable "^1.0.4"
     ws "^5.2.0"
+
+superagent@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-5.0.2.tgz#5ff1e327d7f8250418e76a07fc96f3bd8441ca51"
+  integrity sha512-CqeqvwByDJuLwhcO6NOSuPatyQOIZX/TlvD5GJnXg5tzBTth2xQGZGdAZdo/kX+BtzvwJFX2IGGczTZgEIT7Wg==
+  dependencies:
+    component-emitter "^1.2.1"
+    cookiejar "^2.1.2"
+    debug "^4.1.1"
+    form-data "^2.3.3"
+    formidable "^1.2.1"
+    methods "^1.1.2"
+    mime "^2.4.0"
+    qs "^6.7.0"
+    readable-stream "^3.2.0"
+    semver "^6.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -5846,7 +6086,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -5909,6 +6149,11 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+very-fast-args@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/very-fast-args/-/very-fast-args-1.1.0.tgz#e16d1d1faf8a6e596a246421fd90a77963d0b396"
+  integrity sha1-4W0dH6+KbllqJGQh/ZCneWPQs5Y=
 
 vm-browserify@0.0.4:
   version "0.0.4"
@@ -6147,7 +6392,7 @@ y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
-yallist@^2.1.2:
+yallist@^2.0.0, yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=

--- a/web_client/cypress/integration/LoginPage/steps.js
+++ b/web_client/cypress/integration/LoginPage/steps.js
@@ -1,18 +1,18 @@
 /// <reference types="cypress" />
 
-import { Given, Then } from "cypress-cucumber-preprocessor/steps";
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
 
-Given("I am on the login page", () => {
-  cy.visit("/login");
+Given('I am on the login page', () => {
+  cy.visit('/login');
 });
 
 Then(`I can see a button that says {string}`, buttonText => {
-  cy.get("button")
-    .as("loginButton")
-    .should("contain", buttonText)
-    .and("be.visible");
+  cy.get('button')
+    .as('loginButton')
+    .should('contain', buttonText)
+    .and('be.visible');
 });
 
-Then("I can click the button", () => {
-  cy.get("@loginButton").click();
+Then('I can click the button', () => {
+  cy.get('@loginButton').and('not.be.disabled');
 });

--- a/web_client/cypress/integration/MePage.feature
+++ b/web_client/cypress/integration/MePage.feature
@@ -65,3 +65,9 @@ Feature: Me Page
     When I visit the Me page
     Then I see the title "Me"
     And I see the subtitle "There was an error."
+
+#  I can't figure out how to stub an error response from the mock graphql server.
+#  Scenario: There is an auth error fetching my Thing this week
+#    Given there is a problem with my authentication
+#    When I visit the Me page
+#    Then I am redirected to the page "/login"

--- a/web_client/package.json
+++ b/web_client/package.json
@@ -13,6 +13,7 @@
     "@types/styled-components": "^4.1.11",
     "apollo-cache-inmemory": "^1.5.1",
     "apollo-client": "^2.5.1",
+    "apollo-link-error": "^1.1.10",
     "apollo-link-http": "^1.5.12",
     "auth0-js": "^9.10.1",
     "cypress-graphql-mock": "^0.1.1",

--- a/web_client/package.json
+++ b/web_client/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@types/auth0-js": "^8.11.12",
     "@types/jest": "24.0.9",
     "@types/node": "11.9.5",
     "@types/react": "16.8.5",
@@ -13,6 +14,7 @@
     "apollo-cache-inmemory": "^1.5.1",
     "apollo-client": "^2.5.1",
     "apollo-link-http": "^1.5.12",
+    "auth0-js": "^9.10.1",
     "cypress-graphql-mock": "^0.1.1",
     "graphql": "^14.1.1",
     "graphql-tag": "^2.10.1",

--- a/web_client/src/App.tsx
+++ b/web_client/src/App.tsx
@@ -7,6 +7,7 @@ import { Switch, Route, BrowserRouter as Router } from 'react-router-dom';
 import { ApolloProvider } from 'react-apollo-hooks';
 import AuthenticatedApp from './AuthenticatedApp';
 import { client } from './apollo';
+import CallbackPage from './pages/CallbackPage';
 
 export default function App() {
   return (
@@ -17,6 +18,7 @@ export default function App() {
           <Router>
             <Switch>
               <Route exact path="/login" component={LoginPage} />
+              <Route exact path="/callback" component={CallbackPage} />
               <Route path="/" component={AuthenticatedApp} />
             </Switch>
           </Router>

--- a/web_client/src/apollo.ts
+++ b/web_client/src/apollo.ts
@@ -16,6 +16,7 @@ const typeDefs = gql`
   }
   extend type Mutation {
     logOut: MutationResult!
+    logIn(accessToken: String!): MutationResult!
     setThingInputForm(text: String!): MutationResult!
   }
 `;
@@ -42,6 +43,11 @@ const resolvers: Resolvers = {
     logOut: (_, __, { cache }) => {
       localStorage.removeItem('accessToken');
       cache.writeData({ data: { isLoggedIn: false } });
+      return { success: true };
+    },
+    logIn: (_, { accessToken }: { accessToken: string }, { cache }) => {
+      localStorage.setItem('accessToken', accessToken);
+      cache.writeData({ data: { isLoggedIn: true } });
       return { success: true };
     },
     setThingInputForm: (_, data, { cache }) => {

--- a/web_client/src/apollo.ts
+++ b/web_client/src/apollo.ts
@@ -63,7 +63,7 @@ const resolvers: Resolvers = {
 const authMiddleWare = new ApolloLink((operation, forward) => {
   operation.setContext({
     headers: {
-      authorization: localStorage.getItem('accessToken')
+      Authorization: `Bearer ${localStorage.getItem('accessToken')}`
     }
   });
   if (forward) {

--- a/web_client/src/apollo.ts
+++ b/web_client/src/apollo.ts
@@ -41,9 +41,9 @@ const resolvers: Resolvers = {
     isLoggedIn: (_, __, { cache }) => cache.isLoggedIn
   },
   Mutation: {
-    logOut: (_, __, { cache }) => {
+    logOut: (_, __, { client }) => {
       localStorage.removeItem('accessToken');
-      cache.writeData({ data: { isLoggedIn: false } });
+      client.resetStore();
       return { success: true };
     },
     logIn: (_, { accessToken }: { accessToken: string }, { cache }) => {
@@ -83,6 +83,7 @@ const authErrorAfterware = onError(({ graphQLErrors, operation }) => {
   ) {
     const { cache } = operation.getContext();
     localStorage.removeItem('accessToken');
+    cache.reset();
     cache.writeData({
       data: { isLoggedIn: false }
     });
@@ -101,4 +102,12 @@ export const client = new ApolloClient({
   link,
   resolvers,
   typeDefs
+});
+client.onResetStore(async () => {
+  cache.writeData({
+    data: {
+      isLoggedIn: Boolean(localStorage.getItem('accessToken')),
+      thingInputForm: ''
+    }
+  });
 });

--- a/web_client/src/auth/index.ts
+++ b/web_client/src/auth/index.ts
@@ -1,0 +1,36 @@
+import auth0, { Auth0DecodedHash } from 'auth0-js';
+
+export default class Auth {
+  auth0 = new auth0.WebAuth({
+    domain: 'zhammer.auth0.com',
+    clientID: 'N0Hu8ge6XVTo4VEnIDWpcVqlOyz5VQ7D',
+    redirectUri: 'http://localhost:3000/callback',
+    responseType: 'token id_token',
+    scope: 'openid',
+    audience: 'https://zhammer.auth0.com/api/v2/'
+  });
+
+  login() {
+    this.auth0.authorize();
+  }
+
+  async parseAccessToken(): Promise<string> {
+    const authResult = await new Promise<Auth0DecodedHash>(
+      (resolve, reject) => {
+        this.auth0.parseHash((err, authResult) => {
+          if (err) {
+            reject(err);
+          } else if (authResult === null) {
+            reject('Missing auth result');
+          } else {
+            resolve(authResult);
+          }
+        });
+      }
+    );
+    if (!authResult.accessToken) {
+      throw new Error('Missing access token');
+    }
+    return authResult.accessToken;
+  }
+}

--- a/web_client/src/hooks/useLoginStatus.tsx
+++ b/web_client/src/hooks/useLoginStatus.tsx
@@ -7,6 +7,14 @@ const IS_LOGGED_IN = gql`
   }
 `;
 
+const LOG_IN = gql`
+  mutation LogIn($accessToken: String!) {
+    logIn(accessToken: $accessToken) @client {
+      success
+    }
+  }
+`;
+
 const LOG_OUT = gql`
   mutation LogOut {
     logOut @client {
@@ -18,8 +26,20 @@ const LOG_OUT = gql`
 /**
  * Hook to check if the user is logged in (has an access token in local storage) on component mount.
  */
-export default function useLoginStatus(): [boolean, () => void] {
+export default function useLoginStatus(): [
+  boolean,
+  () => void,
+  (accessToken: string) => void
+] {
   const { data } = useQuery(IS_LOGGED_IN);
   const logout = useMutation(LOG_OUT);
-  return [data.isLoggedIn, logout];
+  const loginMutation = useMutation(LOG_IN);
+  function login(accessToken: string) {
+    loginMutation({
+      variables: {
+        accessToken
+      }
+    });
+  }
+  return [data.isLoggedIn, logout, login];
 }

--- a/web_client/src/pages/CallbackPage/index.tsx
+++ b/web_client/src/pages/CallbackPage/index.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+import useLoginStatus from '../../hooks/useLoginStatus';
+import { Redirect } from 'react-router';
+import Auth from '../../auth';
+
+export default function CallbackPage() {
+  const [isLoggedIn, , login] = useLoginStatus();
+  const [authError, setAuthError] = useState(false);
+  useEffect(() => {
+    handleCallbackPageLoaded();
+  }, []);
+
+  async function handleCallbackPageLoaded() {
+    try {
+      const accessToken = await new Auth().parseAccessToken();
+      login(accessToken);
+    } catch (e) {
+      setAuthError(true);
+    }
+  }
+
+  if (isLoggedIn) return <Redirect to="/me" />;
+  if (authError) return <Redirect to="/login" />;
+  return <div>Loading...</div>;
+}

--- a/web_client/src/pages/LoginPage/index.tsx
+++ b/web_client/src/pages/LoginPage/index.tsx
@@ -8,9 +8,15 @@ import { isMobile } from 'react-device-detect';
 import { ExampleContainer, ButtonContainer } from './LoginPage.styles';
 import { ThingInterface } from '../../types';
 import SeatGeekBlue from '../../components/SeatGeekBlue';
+import Auth from '../../auth';
 
 export default function LoginPage() {
   const things = isMobile ? mobileThings : allThings;
+
+  function handleLoginButtonClicked() {
+    new Auth().login();
+  }
+
   return (
     <Page>
       <Title>One Thing</Title>
@@ -24,7 +30,9 @@ export default function LoginPage() {
         ))}
       </ExampleContainer>
       <ButtonContainer>
-        <Button.Primary>Sign in with Gmail</Button.Primary>
+        <Button.Primary onClick={handleLoginButtonClicked}>
+          Sign in with Gmail
+        </Button.Primary>
       </ButtonContainer>
     </Page>
   );

--- a/web_client/yarn.lock
+++ b/web_client/yarn.lock
@@ -1677,12 +1677,30 @@ apollo-link-dedup@^1.0.0:
     apollo-link "^1.2.9"
     tslib "^1.9.3"
 
+apollo-link-error@^1.1.10:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.1.10.tgz#ce57f0793f0923b598655de5bf5e028d4cf4fba6"
+  integrity sha512-itG5UV7mQqaalmRkuRsF0cUS4zW2ja8XCbxkMZnIEeN24X3yoJi5hpJeAaEkXf0KgYNsR0+rmtCQNruWyxDnZQ==
+  dependencies:
+    apollo-link "^1.2.11"
+    apollo-link-http-common "^0.2.13"
+    tslib "^1.9.3"
+
 apollo-link-http-common@^0.2.11:
   version "0.2.11"
   resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.11.tgz#d4e494ed1e45ea0e0c0ed60f3df64541d0de682d"
   integrity sha512-FjtzEDiG6blH/2MR4fpVNoxdZUFmddP0sez34qnoLaYz6ABFbTDlmRE/dVN79nPExM4Spfs/DtW7KRqyjJ3tOg==
   dependencies:
     apollo-link "^1.2.9"
+    ts-invariant "^0.3.2"
+    tslib "^1.9.3"
+
+apollo-link-http-common@^0.2.13:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.13.tgz#c688f6baaffdc7b269b2db7ae89dae7c58b5b350"
+  integrity sha512-Uyg1ECQpTTA691Fwx5e6Rc/6CPSu4TB4pQRTGIpwZ4l5JDOQ+812Wvi/e3IInmzOZpwx5YrrOfXrtN8BrsDXoA==
+  dependencies:
+    apollo-link "^1.2.11"
     ts-invariant "^0.3.2"
     tslib "^1.9.3"
 
@@ -1705,7 +1723,7 @@ apollo-link@^1.0.0, apollo-link@^1.2.9:
     tslib "^1.9.3"
     zen-observable-ts "^0.8.16"
 
-apollo-link@^1.2.3:
+apollo-link@^1.2.11, apollo-link@^1.2.3:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.11.tgz#493293b747ad3237114ccd22e9f559e5e24a194d"
   integrity sha512-PQvRCg13VduLy3X/0L79M6uOpTh5iHdxnxYuo8yL7sJlWybKRJwsv4IcRBJpMFbChOOaHY7Og9wgPo6DLKDKDA==

--- a/web_client/yarn.lock
+++ b/web_client/yarn.lock
@@ -1158,6 +1158,11 @@
     "@svgr/plugin-svgo" "^4.0.3"
     loader-utils "^1.1.0"
 
+"@types/auth0-js@^8.11.12":
+  version "8.11.12"
+  resolved "https://registry.yarnpkg.com/@types/auth0-js/-/auth0-js-8.11.12.tgz#7d074e393cb93cc40f017687040955ff27e1c485"
+  integrity sha512-HyoxyxZTjF+fn6uWnUbe+F55u31206UJnTH8f00AGswKRpr47WCRFZA+T0KfBpF8l8fwXfq9OT5eb5mAt7nIEw==
+
 "@types/history@*":
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
@@ -1957,6 +1962,19 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+auth0-js@^9.10.1:
+  version "9.10.1"
+  resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-9.10.1.tgz#91feac770006f4703ff6b3463eae41922a99d5e4"
+  integrity sha512-CDePT7UapFLPwp/lqOjL7kMk/lOi7h0AixurxaX+Rey4+4C0NRI+GiRR5u0dJQWSIXyKKOLieHpxzsr0c7VqSg==
+  dependencies:
+    base64-js "^1.2.0"
+    idtoken-verifier "^1.2.0"
+    js-cookie "^2.2.0"
+    qs "^6.4.0"
+    superagent "^3.8.2"
+    url-join "^4.0.0"
+    winchan "^0.2.1"
+
 autoprefixer@^9.4.2:
   version "9.4.7"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.4.7.tgz#f997994f9a810eae47b38fa6d8a119772051c4ff"
@@ -2276,7 +2294,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
   integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
@@ -3231,7 +3249,7 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-component-emitter@^1.2.1:
+component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
@@ -3339,6 +3357,11 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
+
+cookiejar@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
+  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -3454,6 +3477,11 @@ crypto-browserify@^3.0.0, crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-js@^3.1.9-1:
+  version "3.1.9-1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
+  integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
 
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
@@ -5188,7 +5216,7 @@ fork-ts-checker-webpack-plugin-alt@0.4.14:
     resolve "^1.5.0"
     tapable "^1.0.0"
 
-form-data@~2.3.2:
+form-data@^2.3.1, form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
   integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
@@ -5196,6 +5224,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formidable@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
+  integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -5888,6 +5921,17 @@ identity-obj-proxy@3.0.0:
   integrity sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=
   dependencies:
     harmony-reflect "^1.4.6"
+
+idtoken-verifier@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/idtoken-verifier/-/idtoken-verifier-1.2.0.tgz#4654f1f07ab7a803fc9b1b8b36057e2a87ad8b09"
+  integrity sha512-8jmmFHwdPz8L73zGNAXHHOV9yXNC+Z0TUBN5rafpoaFaLFltlIFr1JkQa3FYAETP23eSsulVw0sBiwrE8jqbUg==
+  dependencies:
+    base64-js "^1.2.0"
+    crypto-js "^3.1.9-1"
+    jsbn "^0.1.0"
+    superagent "^3.8.2"
+    url-join "^1.1.0"
 
 ieee754@^1.1.4:
   version "1.1.12"
@@ -6935,6 +6979,11 @@ joi@^11.1.1:
     isemail "3.x.x"
     topo "2.x.x"
 
+js-cookie@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
+  integrity sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s=
+
 js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
@@ -6970,7 +7019,7 @@ js-yaml@^3.12.0, js-yaml@^3.7.0, js-yaml@^3.9.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-jsbn@~0.1.0:
+jsbn@^0.1.0, jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
@@ -7618,7 +7667,7 @@ merge@^1.2.0:
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
   integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
-methods@~1.1.2:
+methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -7702,6 +7751,11 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
+
+mime@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mime@^2.0.3, mime@^2.3.1:
   version "2.4.0"
@@ -9560,6 +9614,11 @@ qs@6.5.2, qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+qs@^6.4.0, qs@^6.5.1:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
 querystring-es3@^0.2.0, querystring-es3@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -9862,7 +9921,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -11091,6 +11150,22 @@ subarg@^1.0.0:
   dependencies:
     minimist "^1.1.0"
 
+superagent@^3.8.2:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  integrity sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
+
 supports-color@5.5.0, supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -11647,6 +11722,16 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
+url-join@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-1.1.0.tgz#741c6c2f4596c4830d6718460920d0c92202dc78"
+  integrity sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=
+
+url-join@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.0.tgz#4d3340e807d3773bda9991f8305acdcc2a665d2a"
+  integrity sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=
+
 url-loader@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-1.1.2.tgz#b971d191b83af693c5e3fea4064be9e1f2d7f8d8"
@@ -12041,6 +12126,11 @@ widest-line@^2.0.0:
   integrity sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==
   dependencies:
     string-width "^2.1.1"
+
+winchan@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/winchan/-/winchan-0.2.1.tgz#19b334e49f7c07c0849f921f405fad87dfc8a1da"
+  integrity sha512-QrG9q+ObfmZBxScv0HSCqFm/owcgyR5Sgpiy1NlCZPpFXhbsmNHhTiLWoogItdBUi0fnU7Io/5ABEqRta5/6Dw==
 
 wordwrap@~0.0.2:
   version "0.0.3"


### PR DESCRIPTION
auth flow is as follows:
- user visits landing page (`/login`)
- user clicks login
- user is redirected to auth0 google social sign in
  * sign in is only permitted for members of the `seatgeek.com` google organization
- on successful login, user is redirected to callback page (`/callback`) with access token from auth0/google
- client saves accesstoken in localstorage and redirects to app (`/me`)
- client makes some request to the one-thing graphql api, sending accesstoken as bearer token
- graphql server parses the the accesstoken jwt, verifies it and extracts the auth0userid for the user
- if it's the user's first time making a request to the server after auth'ing with google
  - server sends a request to auth0 management api to get simple user info (firstname, lastname, email)
  - server stores record of user in db, like
  ```
  | id | auth0UserId | firstName     | lastName | email                |
  | 1  | google-a-12 | Zach          | Hammer   | zhammer@seatgeek.com | 
  ```
   - user is saved to the graphql context, so resolvers know which user is making the request
- if the user has already made a request, server will know by querying for a user where auth0userid matches the current, then sets that user to be the request's user
- once the access token expires -- or if request has a bad accesstoken -- accesstoken jwt verification will fail on the server, server will return an auth error, and client will redirect to `/login` route + clear all user storage